### PR TITLE
Make `Entry.other` public

### DIFF
--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -1362,7 +1362,7 @@ impl Parser {
             pub struct ExtensionSet {
                 #(#ext_set_fields)*
                 /// Extensions unknown to the high-level bindings
-                other: Vec<String>,
+                pub other: Vec<String>,
             }
 
             impl ExtensionSet {

--- a/openxr/src/generated.rs
+++ b/openxr/src/generated.rs
@@ -56,7 +56,7 @@ pub struct ExtensionSet {
     pub oculus_android_session_state_enable: bool,
     pub varjo_quad_views: bool,
     #[doc = r" Extensions unknown to the high-level bindings"]
-    other: Vec<String>,
+    pub other: Vec<String>,
 }
 impl ExtensionSet {
     pub(crate) fn from_properties(properties: &[sys::ExtensionProperties]) -> Self {


### PR DESCRIPTION
I'd like to be able to read from it as well when checking supported extensions