### PR TITLE
Do not panic if missing khr_convert_timespec_time

### DIFF
--- a/openxr/examples/hello.rs
+++ b/openxr/examples/hello.rs
@@ -8,12 +8,9 @@ fn main() {
         .expect("couldn't find the OpenXR loader; try enabling the \"static\" feature");
 
     let extensions = entry.enumerate_extensions().unwrap();
-    println!("supported extensions: {:?}", extensions);
+    println!("supported extensions: {:#?}", extensions);
     let layers = entry.enumerate_layers().unwrap();
     println!("supported layers: {:?}", layers);
-    if !extensions.khr_convert_timespec_time {
-        panic!("timespec conversion unsupported");
-    }
     let instance = entry
         .create_instance(
             &xr::ApplicationInfo {
@@ -47,5 +44,5 @@ fn main() {
     let view_config_views = instance
         .enumerate_view_configuration_views(system, xr::ViewConfigurationType::PRIMARY_STEREO)
         .unwrap();
-    println!("view configuration views: {:?}", view_config_views);
+    println!("view configuration views: {:#?}", view_config_views);
 }


### PR DESCRIPTION
Also pretty-print structs.

Example output:

```
$ cargo run --example hello --features static
supported extensions: ExtensionSet {
    epic_view_configuration_fov: false,
    ext_performance_settings: false,
    ext_thermal_query: false,
    ext_debug_utils: true,
    ext_eye_gaze_interaction: false,
    ext_view_configuration_depth_range: false,
    ext_conformance_automation: false,
    ext_hand_tracking: false,
    ext_win32_appcontainer_compatible: false,
    extx_overlay: false,
    huawei_controller_interaction: false,
    khr_composition_layer_cube: false,
    khr_composition_layer_depth: false,
    khr_vulkan_swapchain_format_list: false,
    khr_composition_layer_cylinder: false,
    khr_composition_layer_equirect: false,
    khr_opengl_enable: false,
    khr_opengl_es_enable: false,
    khr_vulkan_enable: true,
    khr_d3d11_enable: true,
    khr_d3d12_enable: false,
    khr_visibility_mask: true,
    khr_win32_convert_performance_counter_time: true,
    khr_convert_timespec_time: false,
    mnd_headless: false,
    mndx_egl_enable: false,
    msft_unbounded_reference_space: false,
    msft_spatial_anchor: false,
    msft_spatial_graph_bridge: false,
    msft_hand_interaction: false,
    msft_hand_tracking_mesh: false,
    msft_secondary_view_configuration: false,
    msft_first_person_observer: false,
    varjo_quad_views: false,
    other: [],
}
supported layers: []
warning: timespec conversion unsupported
loaded instance: SteamVR/OpenXR v0.1.0
selected system 1153002868467302738: SteamVR/OpenXR : lighthouse
view configuration views: [
    ViewConfigurationView {
        recommended_image_rect_width: 2468,
        max_image_rect_width: 2468,
        recommended_image_rect_height: 2740,
        max_image_rect_height: 2740,
        recommended_swapchain_sample_count: 1,
        max_swapchain_sample_count: 1,
    },
    ViewConfigurationView {
        recommended_image_rect_width: 2468,
        max_image_rect_width: 2468,
        recommended_image_rect_height: 2740,
        max_image_rect_height: 2740,
        recommended_swapchain_sample_count: 1,
        max_swapchain_sample_count: 1,
    },
]

```