### PR TITLE
Fix android

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Install foreign dependencies
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt update && sudo apt-get -y install libxxf86vm-dev libxrandr-dev libgl1-mesa-dev
-      - name: Install cargo-apk
-        if: matrix.target == 'aarch64-linux-android'
-        run: cargo install cargo-apk
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
@@ -49,9 +46,14 @@ jobs:
           args: --workspace --all-targets --target ${{ matrix.target }}
       - uses: actions-rs/cargo@v1
         if: matrix.target == 'aarch64-linux-android'
+        env:
+          TARGET_aarch64_linux_android_CC: ${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-clang
+          TARGET_aarch64_linux_android_CXX: ${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-clang++
+          TARGET_aarch64_linux_android_AR: ${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar
+          RUSTFLAGS: -C linker=aarch64-linux-android-ld.gold
         with:
-          command: apk
-          args: build --manifest-path openxr/Cargo.toml --target ${{ matrix.target }}
+          command: build
+          args: --target ${{ matrix.target }} --manifest-path openxr/Cargo.toml
       - uses: actions-rs/cargo@v1
         if: matrix.target != 'aarch64-linux-android'
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,17 +43,17 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - uses: actions-rs/cargo@v1
-        if: ${{ matrix.target }} != 'aarch64-linux-android'
+        if: matrix.target != 'aarch64-linux-android'
         with:
           command: build
           args: --workspace --all-targets --target ${{ matrix.target }}
       - uses: actions-rs/cargo@v1
-        if: ${{ matrix.target }} == 'aarch64-linux-android'
+        if: matrix.target == 'aarch64-linux-android'
         with:
           command: apk
           args: build --workspace --all-targets --target ${{ matrix.target }}
       - uses: actions-rs/cargo@v1
-        if: ${{ matrix.target }} != 'aarch64-linux-android'
+        if: matrix.target != 'aarch64-linux-android'
         with:
           command: test
           args: --workspace

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,12 +43,12 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - uses: actions-rs/cargo@v1
-        if: ${{ matrix.target }} != 'aarch64-linux-android
+        if: ${{ matrix.target }} != 'aarch64-linux-android'
         with:
           command: build
           args: --workspace --all-targets --target ${{ matrix.target }}
       - uses: actions-rs/cargo@v1
-        if: ${{ matrix.target }} == 'aarch64-linux-android
+        if: ${{ matrix.target }} == 'aarch64-linux-android'
         with:
           command: apk
           args: build --workspace --all-targets --target ${{ matrix.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,7 @@ jobs:
         if: matrix.target == 'aarch64-linux-android'
         with:
           command: apk
-          args: build --workspace --all-targets --target ${{ matrix.target }}
+          args: build --manifest-path openxr/Cargo.toml --target ${{ matrix.target }}
       - uses: actions-rs/cargo@v1
         if: matrix.target != 'aarch64-linux-android'
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install foreign dependencies
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt update && sudo apt-get -y install libxxf86vm-dev libxrandr-dev libgl1-mesa-dev
+      - name: Install cargo-apk
+        if: matrix.target == 'aarch64-linux-android'
+        run: cargo install cargo-apk
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
@@ -40,9 +43,15 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - uses: actions-rs/cargo@v1
+        if: ${{ matrix.target }} != 'aarch64-linux-android
         with:
           command: build
           args: --workspace --all-targets --target ${{ matrix.target }}
+      - uses: actions-rs/cargo@v1
+        if: ${{ matrix.target }} == 'aarch64-linux-android
+        with:
+          command: apk
+          args: build --workspace --all-targets --target ${{ matrix.target }}
       - uses: actions-rs/cargo@v1
         if: ${{ matrix.target }} != 'aarch64-linux-android'
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ['master']
+    branches: ["master"]
   pull_request:
 
 jobs:
@@ -10,12 +10,22 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, beta]
-        exclude:
-          - os: macos-latest
+        include:
+          - os: ubuntu-latest
+            rust: stable
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
             rust: beta
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            rust: stable
+            target: aarch64-linux-android
           - os: windows-latest
-            rust: beta
+            rust: stable
+            target: x86_64-pc-windows-msvc
+          - os: macOS-latest
+            rust: stable
+            target: x86_64-apple-darwin
 
     runs-on: ${{ matrix.os }}
 
@@ -28,12 +38,14 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
           override: true
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace --all-targets
+          args: --workspace --all-targets --target ${{ matrix.target }}
       - uses: actions-rs/cargo@v1
+        if: ${{ matrix.target }} != 'aarch64-linux-android'
         with:
           command: test
           args: --workspace

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,6 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
             rust: stable

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -24,6 +24,9 @@ mint = { version = "0.5.3", optional = true }
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["windef", "ntdef", "d3dcommon", "d3d11", "d3d12"] }
 
+[target.'cfg(target_os = "android")'.dependencies]
+jni = "0.17.0"
+
 [build-dependencies]
 cmake = { version = "0.1.35", optional = true }
 

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -1,5 +1,4 @@
-use std::convert::TryFrom;
-use std::fmt;
+use std::{convert::TryFrom, fmt};
 
 #[macro_use]
 mod support;

--- a/sys/src/platform.rs
+++ b/sys/src/platform.rs
@@ -28,6 +28,9 @@ pub type xcb_glx_context_t = u32;
 // Wayland
 pub type wl_display = c_void;
 
+#[cfg(target_os = "android")]
+pub use jni::sys::jobject;
+
 // Win32
 #[cfg(windows)]
 pub type ID3D10Device = *const c_void;


### PR DESCRIPTION
The `jobject` type is part of the signature of an Android function, this just adds a dependency on the `jni` crate and reexports that type so that Android can compile successfully.

Let me know if you want me to add a build check for Android in CI.