### PR TITLE
Vulkan example tweaks

### DIFF
--- a/openxr/examples/vulkan.rs
+++ b/openxr/examples/vulkan.rs
@@ -445,6 +445,9 @@ fn main() {
                         usage_flags: xr::SwapchainUsageFlags::COLOR_ATTACHMENT
                             | xr::SwapchainUsageFlags::SAMPLED,
                         format: COLOR_FORMAT.as_raw() as _,
+                        // The Vulkan graphics pipeline we create is not set up for multisampling,
+                        // so we hardcode this to 1. If we used a proper multisampling setup, we
+                        // could set this to `views[0].recommended_swapchain_sample_count`.
                         sample_count: 1,
                         width: resolution.width,
                         height: resolution.height,

--- a/openxr/examples/vulkan.rs
+++ b/openxr/examples/vulkan.rs
@@ -58,6 +58,11 @@ fn main() {
     let system = xr_instance
         .system(xr::FormFactor::HEAD_MOUNTED_DISPLAY)
         .unwrap();
+
+    let environment_blend_mode = xr_instance
+        .enumerate_environment_blend_modes(system, xr::ViewConfigurationType::PRIMARY_STEREO)
+        .unwrap()[0];
+
     let vk_instance_exts = xr_instance
         .vulkan_instance_extensions(system)
         .unwrap()
@@ -416,7 +421,7 @@ fn main() {
                 frame_stream
                     .end(
                         xr_frame_state.predicted_display_time,
-                        xr::EnvironmentBlendMode::OPAQUE,
+                        environment_blend_mode,
                         &[],
                     )
                     .unwrap();
@@ -581,7 +586,7 @@ fn main() {
             frame_stream
                 .end(
                     xr_frame_state.predicted_display_time,
-                    xr::EnvironmentBlendMode::OPAQUE,
+                    environment_blend_mode,
                     &[
                         &xr::CompositionLayerProjection::new().space(&stage).views(&[
                             xr::CompositionLayerProjectionView::new()

--- a/openxr/examples/vulkan.rs
+++ b/openxr/examples/vulkan.rs
@@ -464,8 +464,8 @@ fn main() {
                 // property of the view configuration type; in this example we use PRIMARY_STEREO,
                 // so we should have 2 viewpoints.
                 //
-                // Because we are using multiview in this example, we will only look at the first
-                // viewpoint, and assume that the other viewpoints are identical.
+                // Because we are using multiview in this example, we require that all view
+                // dimensions are identical.
                 let views = xr_instance
                     .enumerate_view_configuration_views(system, VIEW_TYPE)
                     .unwrap();


### PR DESCRIPTION
Includes a couple of small tweaks to improve the robustness of the example.

I also ported over some documentation from @maluoi's C++ example code, that was helpful for me in working out what was going on in this implementation. I think this is acceptable usage (both examples are MIT-licensed), but @maluoi LMK if you'd prefer this not be included.