### PR TITLE
Support drop guard for session

### DIFF
--- a/openxr/src/instance.rs
+++ b/openxr/src/instance.rs
@@ -368,7 +368,26 @@ impl Instance {
         info: &G::SessionCreateInfo,
     ) -> Result<(Session<G>, FrameWaiter, FrameStream<G>)> {
         let handle = G::create_session(self, system, info)?;
-        Ok(Session::from_raw(self.clone(), handle))
+        Ok(Session::from_raw(self.clone(), handle, Box::new(())))
+    }
+
+    /// Refer to [`Instance::create_session()`]. The extra `drop_guard` argument is dropped after
+    /// the session is destroyed and this can be used to ensure safety.
+    ///
+    /// # Safety
+    ///
+    /// The requirements documented by the graphics API extension must be respected. Among other
+    /// requirements, `info` must contain valid handles, and certain operations must be externally
+    /// synchronized.
+    #[inline]
+    pub unsafe fn create_session_with_guard<G: Graphics>(
+        &self,
+        system: SystemId,
+        info: &G::SessionCreateInfo,
+        drop_guard: DropGuard,
+    ) -> Result<(Session<G>, FrameWaiter, FrameStream<G>)> {
+        let handle = G::create_session(self, system, info)?;
+        Ok(Session::from_raw(self.clone(), handle, drop_guard))
     }
 
     /// Get the next event, if available


### PR DESCRIPTION
This PR allows to pass a custom object to `Instance::create_session()` used to force a specific drop order. In particular, in case the graphics device and instance is kept around in a clonable object (with a proper `impl Drop`) and its time of destruction is unknown, the `drop_guard` argument should be set to a clone of this object. For context, here is a related PR: https://github.com/gfx-rs/wgpu/pull/1609

This is needed for OpenXR support in bevy. Until now this solution was used:

```rust
#[derive(Clone)]
pub struct OpenXrSession {
    inner: Option<xr::Session<xr::AnyGraphics>>,
    _wgpu_device: Arc<wgpu::Device>,
}

impl Deref for OpenXrSession {
    type Target = xr::Session<xr::AnyGraphics>;

    fn deref(&self) -> &Self::Target {
        self.inner.as_ref().unwrap()
    }
}

impl Drop for OpenXrSession {
    fn drop(&mut self) {
        // Drop OpenXR session before wgpu::Device.
        self.inner.take();
    }
}
```

Instead of exposing `openxr::Session` to the user directly, this `OpenXrSession` object is used. But the underlying `openxr::Session` is still cloned by the bevy plugin implementation (for interop with graphics), and this makes it tricky to ensure safety.

The vulkan example is updated, but it passes `None` as the drop guard since the drop order is already enforced and the example is linear.