### PR TITLE
Replace ndk-glue with ndk-context

### DIFF
--- a/openxr/Cargo.toml
+++ b/openxr/Cargo.toml
@@ -33,7 +33,7 @@ ctrlc = "3.1.5"
 winapi = { version = "0.3", features = ["profileapi"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk-glue = "0.6"
+ndk-context = "0.1"
 
 [package.metadata.docs.rs]
 features = ["linked", "loaded", "mint"]

--- a/openxr/src/entry.rs
+++ b/openxr/src/entry.rs
@@ -113,13 +113,13 @@ impl Entry {
     pub fn initialize_android_loader(&self) -> Result<()> {
         let loader_init = unsafe { raw::LoaderInitKHR::load(self, sys::Instance::NULL)? };
 
-        let native_activity = ndk_glue::native_activity();
+        let context = ndk_context::android_context();
 
         let loader_info = sys::LoaderInitInfoAndroidKHR {
             ty: sys::LoaderInitInfoAndroidKHR::TYPE,
             next: ptr::null(),
-            application_vm: native_activity.vm() as _,
-            application_context: native_activity.activity() as _,
+            application_vm: context.vm(),
+            application_context: context.context(),
         };
 
         unsafe {
@@ -170,13 +170,13 @@ impl Entry {
         let next = ptr::null();
         #[cfg(target_os = "android")]
         let android_info = {
-            let native_activity = ndk_glue::native_activity();
+            let context = ndk_context::android_context();
 
             sys::InstanceCreateInfoAndroidKHR {
                 ty: sys::InstanceCreateInfoAndroidKHR::TYPE,
                 next: ptr::null(),
-                application_vm: native_activity.vm() as _,
-                application_activity: native_activity.activity() as _,
+                application_vm: context.vm(),
+                application_activity: context.context(),
             }
         };
         #[cfg(target_os = "android")]


### PR DESCRIPTION
ndk-glue provides the application entry point and was never supposed to be used by library crates. ndk-context provides the bare minimum that libraries need for plugging into the android context (VM and Context pointers); it has no dependencies and will be updated a lot less (ideally not anymore) so it becomes a stable foundation for the android crates ecosystem.

ndk-glue 0.6.1 already initializes ndk-context. This PR is not a breaking change.