### PR TITLE
openxr-sys: bump cmake dependency version

### DIFF
--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -3,7 +3,7 @@ name = "openxr-sys"
 description = "OpenXR FFI bindings"
 repository = "https://github.com/Ralith/openxrs"
 readme = "../README.md"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>"]
 categories = ["external-ffi-bindings", "rendering"]
 keywords = ["openxr", "vr"]
@@ -28,7 +28,7 @@ winapi = { version = "0.3", features = ["windef", "ntdef", "d3dcommon", "d3d11",
 jni = "0.19.0"
 
 [build-dependencies]
-cmake = { version = "0.1.35", optional = true }
+cmake = { version = "0.1.48", optional = true }
 
 [package.metadata.docs.rs]
 features = ["linked", "mint"]


### PR DESCRIPTION
`cmake` 0.1.47 introduced VS2022 support, so I've updated the version to take advantage of that.