### PR TITLE
Remove winapi dependency by inlining definitions

### DIFF
--- a/openxr/Cargo.toml
+++ b/openxr/Cargo.toml
@@ -29,9 +29,6 @@ libloading = { version = "0.7", optional = true }
 ash = { version = "0.37", default-features = false, features = ["loaded"] }
 ctrlc = "3.1.5"
 
-[target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["profileapi"] }
-
 [target.'cfg(target_os = "android")'.dependencies]
 ndk-context = "0.1"
 

--- a/openxr/src/instance.rs
+++ b/openxr/src/instance.rs
@@ -543,9 +543,13 @@ impl Instance {
     #[inline]
     #[cfg(windows)]
     pub fn now(&self) -> Result<Time> {
+        extern "system" {
+            fn QueryPerformanceCounter(lpperformancecount: *mut i64) -> i32;
+        }
+
         unsafe {
             let mut now = MaybeUninit::uninit();
-            winapi::um::profileapi::QueryPerformanceCounter(now.as_mut_ptr());
+            QueryPerformanceCounter(now.as_mut_ptr());
             let now = now.assume_init();
             let mut out = MaybeUninit::uninit();
             cvt((self

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -21,9 +21,6 @@ static = ["cmake", "linked"]
 libc = "0.2.50"
 mint = { version = "0.5.3", optional = true }
 
-[target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["windef", "ntdef", "d3dcommon", "d3d11", "d3d12"] }
-
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.19.0"
 

--- a/sys/src/platform.rs
+++ b/sys/src/platform.rs
@@ -43,25 +43,35 @@ pub use jni::sys::jobject;
 
 // Win32
 #[cfg(windows)]
-pub type ID3D10Device = *const c_void;
+pub use windows::*;
 #[cfg(windows)]
-pub type ID3D10Texture2D = *const c_void;
-#[cfg(windows)]
-pub type D3D10_FEATURE_LEVEL1 = u32;
-#[cfg(windows)]
-pub use winapi::{
-    shared::{
-        ntdef::LUID,
-        windef::{HDC, HGLRC},
-    },
-    um::{
-        d3d11::{ID3D11Device, ID3D11Texture2D},
-        d3d12::{ID3D12CommandQueue, ID3D12Device, ID3D12Resource},
-        d3dcommon::D3D_FEATURE_LEVEL,
-        unknwnbase::IUnknown,
-        winnt::LARGE_INTEGER,
-    },
-};
+#[allow(non_snake_case)]
+mod windows {
+    //! Transcribed from windows-sys
+
+    use std::os::raw::c_void;
+
+    pub type IUnknown = *mut c_void;
+    pub type ID3D10Device = *const c_void;
+    pub type ID3D10Texture2D = *const c_void;
+    pub type D3D10_FEATURE_LEVEL1 = u32;
+    pub type LARGE_INTEGER = i64;
+    pub type HDC = isize;
+    pub type HGLRC = isize;
+    pub type ID3D11Device = *mut c_void;
+    pub type ID3D11Texture2D = *mut c_void;
+    pub type ID3D12CommandQueue = *mut c_void;
+    pub type ID3D12Device = *mut c_void;
+    pub type ID3D12Resource = *mut c_void;
+    pub type D3D_FEATURE_LEVEL = i32;
+
+    #[derive(Copy, Clone)]
+    #[repr(C)]
+    pub struct LUID {
+        pub LowPart: u32,
+        pub HighPart: i32,
+    }
+}
 
 // EGL
 pub type EGLConfig = *mut c_void;


### PR DESCRIPTION
Reduces build bloat.