### PR TITLE
Add features for layer development

### DIFF
--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -1031,7 +1031,7 @@ impl Parser {
             quote! {
                 #[doc = #doc]
                 #[repr(transparent)]
-                #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+                #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
                 pub struct #ident(u64);
                 handle!(#ident);
             }

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -1191,7 +1191,7 @@ impl Parser {
         quote! {
             //! Automatically generated code; do not edit!
 
-            #![allow(non_upper_case_globals, clippy::unreadable_literal, clippy::identity_op, unused)]
+            #![allow(non_upper_case_globals, clippy::unreadable_literal, clippy::identity_op, unused, clippy::derive_partial_eq_without_eq)]
             use std::fmt;
             use std::mem::MaybeUninit;
             use std::os::raw::{c_void, c_char};

--- a/sys/src/generated.rs
+++ b/sys/src/generated.rs
@@ -3,7 +3,8 @@
     non_upper_case_globals,
     clippy::unreadable_literal,
     clippy::identity_op,
-    unused
+    unused,
+    clippy::derive_partial_eq_without_eq
 )]
 use crate::platform::*;
 use crate::support::*;

--- a/sys/src/generated.rs
+++ b/sys/src/generated.rs
@@ -2464,92 +2464,92 @@ impl DigitalLensControlFlagsALMALENCE {
 bitmask!(DigitalLensControlFlagsALMALENCE);
 #[doc = "See [XrInstance](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrInstance)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Instance(u64);
 handle!(Instance);
 #[doc = "See [XrSession](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrSession)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Session(u64);
 handle!(Session);
 #[doc = "See [XrActionSet](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrActionSet)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct ActionSet(u64);
 handle!(ActionSet);
 #[doc = "See [XrAction](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrAction)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Action(u64);
 handle!(Action);
 #[doc = "See [XrSwapchain](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrSwapchain)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Swapchain(u64);
 handle!(Swapchain);
 #[doc = "See [XrSpace](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrSpace)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Space(u64);
 handle!(Space);
 #[doc = "See [XrDebugUtilsMessengerEXT](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrDebugUtilsMessengerEXT)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct DebugUtilsMessengerEXT(u64);
 handle!(DebugUtilsMessengerEXT);
 #[doc = "See [XrSpatialAnchorMSFT](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrSpatialAnchorMSFT)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct SpatialAnchorMSFT(u64);
 handle!(SpatialAnchorMSFT);
 #[doc = "See [XrHandTrackerEXT](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrHandTrackerEXT)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct HandTrackerEXT(u64);
 handle!(HandTrackerEXT);
 #[doc = "See [XrFoveationProfileFB](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrFoveationProfileFB)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct FoveationProfileFB(u64);
 handle!(FoveationProfileFB);
 #[doc = "See [XrTriangleMeshFB](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrTriangleMeshFB)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct TriangleMeshFB(u64);
 handle!(TriangleMeshFB);
 #[doc = "See [XrPassthroughFB](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrPassthroughFB)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct PassthroughFB(u64);
 handle!(PassthroughFB);
 #[doc = "See [XrPassthroughLayerFB](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrPassthroughLayerFB)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct PassthroughLayerFB(u64);
 handle!(PassthroughLayerFB);
 #[doc = "See [XrGeometryInstanceFB](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrGeometryInstanceFB)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct GeometryInstanceFB(u64);
 handle!(GeometryInstanceFB);
 #[doc = "See [XrSceneObserverMSFT](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrSceneObserverMSFT)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct SceneObserverMSFT(u64);
 handle!(SceneObserverMSFT);
 #[doc = "See [XrSceneMSFT](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrSceneMSFT)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct SceneMSFT(u64);
 handle!(SceneMSFT);
 #[doc = "See [XrSpatialAnchorStoreConnectionMSFT](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrSpatialAnchorStoreConnectionMSFT)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct SpatialAnchorStoreConnectionMSFT(u64);
 handle!(SpatialAnchorStoreConnectionMSFT);
 #[doc = "See [XrFacialTrackerHTC](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrFacialTrackerHTC)"]
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct FacialTrackerHTC(u64);
 handle!(FacialTrackerHTC);
 #[repr(C)]

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -3,6 +3,7 @@ use std::{convert::TryFrom, fmt};
 #[macro_use]
 mod support;
 mod generated;
+pub mod loader;
 pub mod platform;
 
 #[cfg(feature = "mint")]

--- a/sys/src/loader.rs
+++ b/sys/src/loader.rs
@@ -1,0 +1,152 @@
+use crate::generated::*;
+use crate::support::fmt_enum;
+use crate::Version;
+
+/// Function pointer prototype for the xrCreateApiLayerInstance function used in place of xrCreateInstance.
+/// This function allows us to pass special API layer information to each layer during the process of creating an Instance.
+pub type FnCreateApiLayerInstance = unsafe extern "system" fn(
+    info: *const InstanceCreateInfo,
+    api_layer_info: *const ApiLayerCreateInfo,
+    instance: *mut Instance,
+) -> Result;
+
+/// Loader/API Layer Interface versions
+///
+///  1 - First version, introduces negotiation structure and functions
+pub const CURRENT_LOADER_API_LAYER_VERSION: u32 = 1;
+
+/// Loader/Runtime Interface versions
+///
+///  1 - First version, introduces negotiation structure and functions
+pub const CURRENT_LOADER_RUNTIME_VERSION: u32 = 1;
+
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct LoaderInterfaceStructureType(i32);
+impl LoaderInterfaceStructureType {
+    pub const UNINTIALIZED: Self = Self(0);
+    pub const LOADER_INFO: Self = Self(1);
+    pub const API_LAYER_REQUEST: Self = Self(2);
+    pub const RUNTIME_REQUEST: Self = Self(3);
+    pub const API_LAYER_CREATE_INFO: Self = Self(4);
+    pub const API_LAYER_NEXT_INFO: Self = Self(5);
+}
+
+impl core::fmt::Debug for LoaderInterfaceStructureType {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match *self {
+            Self::UNINTIALIZED => Some("UNINTIALIZED"),
+            Self::LOADER_INFO => Some("LOADER_INFO"),
+            Self::API_LAYER_REQUEST => Some("API_LAYER_REQUEST"),
+            Self::RUNTIME_REQUEST => Some("RUNTIME_REQUEST"),
+            Self::API_LAYER_CREATE_INFO => Some("API_LAYER_CREATE_INFO"),
+            Self::API_LAYER_NEXT_INFO => Some("API_LAYER_NEXT_INFO"),
+            _ => None,
+        };
+        fmt_enum(fmt, self.0, name)
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct XrNegotiateLoaderInfo {
+    pub ty: LoaderInterfaceStructureType,
+    pub struct_version: u32,
+    pub struct_size: usize,
+    pub min_interface_version: u32,
+    pub max_interface_version: u32,
+    pub min_api_version: Version,
+    pub max_api_version: Version,
+}
+impl XrNegotiateLoaderInfo {
+    pub const TYPE: LoaderInterfaceStructureType = LoaderInterfaceStructureType::LOADER_INFO;
+    pub const VERSION: u32 = 1;
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct XrNegotiateApiLayerRequest {
+    pub ty: LoaderInterfaceStructureType,
+    pub struct_version: u32,
+    pub struct_size: usize,
+    pub layer_interface_version: u32,
+    pub layer_api_version: Version,
+    pub get_instance_proc_addr: Option<pfn::GetInstanceProcAddr>,
+    pub create_api_layer_instance: Option<FnCreateApiLayerInstance>,
+}
+impl XrNegotiateApiLayerRequest {
+    pub const TYPE: LoaderInterfaceStructureType = LoaderInterfaceStructureType::API_LAYER_REQUEST;
+    pub const VERSION: u32 = 1;
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct XrNegotiateRuntimeRequest {
+    pub ty: LoaderInterfaceStructureType,
+    pub struct_version: u32,
+    pub struct_size: usize,
+    pub runtime_interface_version: u32,
+    pub runtime_api_version: Version,
+    pub get_instance_proc_addr: Option<pfn::GetInstanceProcAddr>,
+}
+impl XrNegotiateRuntimeRequest {
+    pub const TYPE: LoaderInterfaceStructureType = LoaderInterfaceStructureType::RUNTIME_REQUEST;
+    pub const VERSION: u32 = 1;
+}
+
+/// Function used to negotiate an interface between the loader and an API layer.  Each library exposing one or
+/// more API layers needs to expose at least this function.
+pub type FnNegotiateLoaderApiLayerInterface = unsafe extern "system" fn(
+    loader_info: *const XrNegotiateLoaderInfo,
+    api_layer_name: *const i8,
+    api_layer_request: *mut XrNegotiateApiLayerRequest,
+) -> Result;
+
+/// Function used to negotiate an interface between the loader and a runtime.  Each runtime should expose
+/// at least this function.
+pub type FnNegotiateLoaderRuntimeInterface = unsafe extern "system" fn(
+    loader_info: *const XrNegotiateLoaderInfo,
+    runtime_request: *mut XrNegotiateRuntimeRequest,
+) -> Result;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct XrApiLayerNextInfo {
+    pub ty: LoaderInterfaceStructureType,
+    pub struct_version: u32,
+    pub struct_size: usize,
+    /// Name of API layer which should receive this info
+    pub layer_name: [i8; MAX_API_LAYER_NAME_SIZE],
+    /// Pointer to next API layer's xrGetInstanceProcAddr
+    pub next_get_instance_proc_addr: pfn::GetInstanceProcAddr,
+    /// Pointer to next API layer's xrCreateApiLayerInstance
+    pub next_create_api_layer_instance: FnCreateApiLayerInstance,
+    /// Pointer to the next API layer info in the sequence
+    pub next: *mut XrApiLayerNextInfo,
+}
+impl XrApiLayerNextInfo {
+    pub const TYPE: LoaderInterfaceStructureType =
+        LoaderInterfaceStructureType::API_LAYER_NEXT_INFO;
+    pub const VERSION: u32 = 1;
+}
+
+pub const API_LAYER_MAX_SETTINGS_PATH_SIZE: usize = 512;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct ApiLayerCreateInfo {
+    pub ty: LoaderInterfaceStructureType,
+    pub struct_version: u32,
+    pub struct_size: usize,
+    /// Pointer to the LoaderInstance class
+    pub loader_instance: *const (),
+    /// Location to the found settings file (or empty '\0')
+    pub settings_file_location: [i8; API_LAYER_MAX_SETTINGS_PATH_SIZE],
+    /// Pointer to the next API layer's Info
+    pub next_info: *mut XrApiLayerNextInfo,
+}
+impl ApiLayerCreateInfo {
+    pub const TYPE: LoaderInterfaceStructureType =
+        LoaderInterfaceStructureType::API_LAYER_CREATE_INFO;
+    pub const VERSION: u32 = 1;
+}


### PR DESCRIPTION
This makes two minor changes to make openxrs more practical for developing an OpenXR layer.

Adding Hash to raw handle types makes it simpler to manage all the tracked handles like so:
```rs
static mut INSTANCE_WRAPPERS: OnceCell<DashMap<xr::Instance, Arc<instance::InstanceWrapper>>> = OnceCell::new();
```

And the added bindings from [loader_interfaces.h](https://github.com/KhronosGroup/OpenXR-SDK-Source/blob/main/src/common/loader_interfaces.h) are used for Runtime-Loader-Layer negotiation.
