### PR TITLE
Added links field to cargo.toml

### DIFF
--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -10,6 +10,8 @@ keywords = ["openxr", "vr"]
 license = "MIT/Apache-2.0"
 edition = "2018"
 
+links = "openxr_loader"
+
 [badges]
 maintenance = { status = "experimental" }
 


### PR DESCRIPTION
Generally, -sys crates should specify the [links field](https://doc.rust-lang.org/cargo/reference/manifest.html#the-links-field). This is important because cargo provides mechanisms to [override the linker search path](https://doc.rust-lang.org/cargo/reference/config.html#targettriplelinks) using this field.

[Example usage](https://github.com/NexusSocial/nexus-vr/pull/3)