### PR TITLE
Add basic D3D12 bindings

### DIFF
--- a/openxr/src/graphics/d3d.rs
+++ b/openxr/src/graphics/d3d.rs
@@ -13,7 +13,7 @@ pub enum D3D11 {}
 
 impl Graphics for D3D11 {
     type Requirements = Requirements;
-    type SessionCreateInfo = SessionCreateInfo;
+    type SessionCreateInfo = SessionCreateInfoD3D11;
     type Format = u32;
     type SwapchainImage = *mut ID3D11Texture2D;
 
@@ -87,6 +87,91 @@ impl Graphics for D3D11 {
     }
 }
 
+
+/// The D3D12 graphics API
+///
+/// See [`XR_KHR_d3d12_enable`] for safety details.
+///
+/// [`XR_KHR_d3d_enable`]: https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XR_KHR_D3D12_enable
+pub enum D3D12 {}
+
+impl Graphics for D3D12 {
+    type Requirements = Requirements;
+    type SessionCreateInfo = SessionCreateInfoD3D12;
+    type Format = u32;
+    type SwapchainImage = *mut ID3D12Resource;
+
+    fn raise_format(x: i64) -> u32 {
+        x as _
+    }
+    fn lower_format(x: u32) -> i64 {
+        x.into()
+    }
+
+    fn requirements(inst: &Instance, system: SystemId) -> Result<Requirements> {
+        let out = unsafe {
+            let mut x = sys::GraphicsRequirementsD3D12KHR::out(ptr::null_mut());
+            cvt((inst.d3d12().get_d3d12_graphics_requirements)(
+                inst.as_raw(),
+                system,
+                x.as_mut_ptr(),
+            ))?;
+            x.assume_init()
+        };
+        Ok(Requirements {
+            adapter_luid: out.adapter_luid,
+            min_feature_level: out.min_feature_level,
+        })
+    }
+
+    unsafe fn create_session(
+        instance: &Instance,
+        system: SystemId,
+        info: &Self::SessionCreateInfo,
+    ) -> Result<sys::Session> {
+        let binding = sys::GraphicsBindingD3D12KHR {
+            ty: sys::GraphicsBindingD3D12KHR::TYPE,
+            next: ptr::null(),
+            device: info.device,
+            queue: info.queue,
+        };
+        let info = sys::SessionCreateInfo {
+            ty: sys::SessionCreateInfo::TYPE,
+            next: &binding as *const _ as *const _,
+            create_flags: Default::default(),
+            system_id: system,
+        };
+        let mut out = sys::Session::NULL;
+        cvt((instance.fp().create_session)(
+            instance.as_raw(),
+            &info,
+            &mut out,
+        ))?;
+        Ok(out)
+    }
+
+    fn enumerate_swapchain_images(
+        swapchain: &Swapchain<Self>,
+    ) -> Result<Vec<Self::SwapchainImage>> {
+        let images = get_arr_init(
+            sys::SwapchainImageD3D12KHR {
+                ty: sys::SwapchainImageD3D12KHR::TYPE,
+                next: ptr::null_mut(),
+                texture: ptr::null_mut(),
+            },
+            |capacity, count, buf| unsafe {
+                (swapchain.instance().fp().enumerate_swapchain_images)(
+                    swapchain.as_raw(),
+                    capacity,
+                    count,
+                    buf as *mut _,
+                )
+            },
+        )?;
+        Ok(images.into_iter().map(|x| x.texture).collect())
+    }
+}
+
 #[derive(Copy, Clone)]
 pub struct Requirements {
     pub adapter_luid: LUID,
@@ -94,6 +179,12 @@ pub struct Requirements {
 }
 
 #[derive(Copy, Clone)]
-pub struct SessionCreateInfo {
+pub struct SessionCreateInfoD3D11 {
     pub device: *mut ID3D11Device,
+}
+
+#[derive(Copy, Clone)]
+pub struct SessionCreateInfoD3D12 {
+    pub device: *mut ID3D12Device,
+    pub queue: *mut ID3D12CommandQueue,
 }

--- a/openxr/src/graphics/mod.rs
+++ b/openxr/src/graphics/mod.rs
@@ -38,6 +38,8 @@ pub trait Graphics: Sized {
 pub mod d3d;
 #[cfg(windows)]
 pub use d3d::D3D11;
+#[cfg(windows)]
+pub use d3d::D3D12;
 
 pub mod vulkan;
 pub use vulkan::Vulkan;

--- a/openxr/src/instance.rs
+++ b/openxr/src/instance.rs
@@ -669,6 +669,13 @@ impl Instance {
             .as_ref()
             .expect("KHR_d3d11_enable not loaded")
     }
+    #[cfg(windows)]
+    pub(crate) fn d3d12(&self) -> &raw::D3d12EnableKHR {
+        self.exts()
+            .khr_d3d12_enable
+            .as_ref()
+            .expect("KHR_d3d12_enable not loaded")
+    }
     pub(crate) fn visibility_mask(&self) -> &raw::VisibilityMaskKHR {
         self.exts()
             .khr_visibility_mask


### PR DESCRIPTION
This PR copies the D3D11 bindings with minor modifications to work for D3D12. It at least works for me as used in awtterpip/bevy_oxr/pull/50, but there may be some subtleties that I've missed.