### PR TITLE
Remove null terminators from other extensions

### DIFF
--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -1518,6 +1518,7 @@ impl Parser {
                             #(#ext_set_inits)*
                             bytes => {
                                 if let Ok(name) = std::str::from_utf8(bytes) {
+                                    // This is probably always true but we check just to be sure.
                                     if bytes.last() == Some(&0) {
                                         out.other.push(name[0..(bytes.len() - 1)].into());
                                     } else {

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -1520,7 +1520,10 @@ impl Parser {
                             bytes => {
                                 let cstr = CStr::from_bytes_with_nul(bytes)
                                     .expect("extension names should be null terminated strings");
-                                let string = String::from_utf8_lossy(cstr.to_bytes()).to_string();
+                                let string = cstr
+                                    .to_str()
+                                    .expect("extension names should be valid UTF-8")
+                                    .to_string();
                                 out.other.push(string);
                             }
                         }

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -1518,7 +1518,11 @@ impl Parser {
                             #(#ext_set_inits)*
                             bytes => {
                                 if let Ok(name) = std::str::from_utf8(bytes) {
-                                    out.other.push(name.into());
+                                    if bytes.last() == Some(&0) {
+                                        out.other.push(name[0..(bytes.len() - 1)].into());
+                                    } else {
+                                        out.other.push(name.into());
+                                    }
                                 }
                             }
                         }

--- a/openxr/src/generated.rs
+++ b/openxr/src/generated.rs
@@ -689,7 +689,10 @@ impl ExtensionSet {
                 bytes => {
                     let cstr = CStr::from_bytes_with_nul(bytes)
                         .expect("extension names should be null terminated strings");
-                    let string = String::from_utf8_lossy(cstr.to_bytes()).to_string();
+                    let string = cstr
+                        .to_str()
+                        .expect("extension names should be valid UTF-8")
+                        .to_string();
                     out.other.push(string);
                 }
             }

--- a/openxr/src/generated.rs
+++ b/openxr/src/generated.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::wrong_self_convention, clippy::transmute_ptr_to_ptr)]
 use crate::*;
 use std::borrow::Cow;
+use std::ffi::CStr;
 use std::mem::MaybeUninit;
 pub use sys::platform::{
     EGLenum, VkComponentSwizzle, VkFilter, VkSamplerAddressMode, VkSamplerMipmapMode,
@@ -686,13 +687,10 @@ impl ExtensionSet {
                     out.htcx_vive_tracker_interaction = true;
                 }
                 bytes => {
-                    if let Ok(name) = std::str::from_utf8(bytes) {
-                        if bytes.last() == Some(&0) {
-                            out.other.push(name[0..(bytes.len() - 1)].into());
-                        } else {
-                            out.other.push(name.into());
-                        }
-                    }
+                    let cstr = CStr::from_bytes_with_nul(bytes)
+                        .expect("extension names should be null terminated strings");
+                    let string = String::from_utf8_lossy(cstr.to_bytes()).to_string();
+                    out.other.push(string);
                 }
             }
         }

--- a/openxr/src/generated.rs
+++ b/openxr/src/generated.rs
@@ -687,7 +687,11 @@ impl ExtensionSet {
                 }
                 bytes => {
                     if let Ok(name) = std::str::from_utf8(bytes) {
-                        out.other.push(name.into());
+                        if bytes.last() == Some(&0) {
+                            out.other.push(name[0..(bytes.len() - 1)].into());
+                        } else {
+                            out.other.push(name.into());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The field `other` in `ExtensionSet` currently handles null terminated strings in a weird way. It adds null terminators in `fn names` but doesn't remove them in `fn from_properties`. I got bit by this when checking for extensions by name and not having null terminators in my strings. I think it would make the most sense to not have null terminators in `String`s.