### PR TITLE
implement FB_render_model

### DIFF
--- a/openxr/src/instance.rs
+++ b/openxr/src/instance.rs
@@ -150,6 +150,23 @@ impl Instance {
     }
 
     #[inline]
+    pub fn supports_render_model_loading(&self, system: SystemId) -> Result<bool> {
+        unsafe {
+            let mut render_model = sys::SystemRenderModelPropertiesFB::out(ptr::null_mut());
+            let mut p = sys::SystemProperties::out(&mut render_model as *mut _ as _);
+            cvt((self.fp().get_system_properties)(
+                self.as_raw(),
+                system,
+                p.as_mut_ptr(),
+            ))?;
+            Ok(render_model
+                .assume_init()
+                .supports_render_model_loading
+                .into())
+        }
+    }
+
+    #[inline]
     pub fn supports_hand_tracking(&self, system: SystemId) -> Result<bool> {
         unsafe {
             let mut hand = sys::SystemHandTrackingPropertiesEXT::out(ptr::null_mut());
@@ -681,6 +698,12 @@ impl Instance {
             .khr_visibility_mask
             .as_ref()
             .expect("KHR_visibility_mask not loaded")
+    }
+    pub(crate) fn render_model_fb(&self) -> &raw::RenderModelFB {
+        self.exts()
+            .fb_render_model
+            .as_ref()
+            .expect("FB_render_model not loaded")
     }
 }
 

--- a/openxr/src/session.rs
+++ b/openxr/src/session.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 use std::{marker::PhantomData, ptr, sync::Arc};
 
-use sys::{RenderModelKeyFB, RenderModelLoadInfoFB};
+pub use sys::{RenderModelKeyFB, RenderModelLoadInfoFB};
 
 use crate::*;
 

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -143,6 +143,10 @@ wrapper! {
     RenderModelKeyFB(u64)
 }
 
+impl RenderModelKeyFB {
+    pub const NULL: RenderModelKeyFB = RenderModelKeyFB(0);
+}
+
 wrapper! {
     #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
     MarkerML(u64)


### PR DESCRIPTION
Implements the [`FB_render_model`](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_FB_render_model) extension.