### PR TITLE
fix cross-compiling static loader

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -16,13 +16,13 @@ fn main() {
         );
         println!("cargo:rustc-link-lib=static=openxr_loader");
 
-        if cfg!(any(target_os = "macos", target_os = "freebsd")) {
+        let target_os = std::env::var_os("CARGO_CFG_TARGET_OS")
+            .expect("missing CARGO_CFG_TARGET_OS environment variable");
+
+        if target_os == "macos" || target_os == "freebsd" {
             println!("cargo:rustc-link-lib=c++");
-        } else if cfg!(target_os = "windows") {
-            println!("cargo:rustc-link-lib=pathcch");
-        } else {
+        } else if target_os != "windows" {
             println!("cargo:rustc-link-lib=stdc++");
-            println!("cargo:rustc-link-lib=stdc++fs");
         }
     }
     #[cfg(all(not(feature = "static"), feature = "linked"))]


### PR DESCRIPTION
The build script used the `cfg!` macro to check the target os, but the "target" in a build script is actually the host. Use the `CARGO_CFG_TARGET_OS` environment variable instead.

Issue #42 [has been worked around](https://github.com/KhronosGroup/OpenXR-SDK-Source/pull/198), and then [fixed upstream](https://github.com/KhronosGroup/OpenXR-SDK-Source/pull/239), so the additional flag on windows is no longer necessary.

Linking the filesystem library is also done correctly upstream now: https://github.com/KhronosGroup/OpenXR-SDK-Source/blob/main/src/cmake/StdFilesystemFlags.cmake

---

I'm not sure the remaining flags are necessary anymore, but I don't have a macOS/FreeBDS/Linux setup to test it.

If anyone else wants to cross-compile the loader from Windows to Android, you probably have to use [ninja](https://ninja-build.org/) with the `CMAKE_GENERATOR=Ninja` environment variable because MSBuild adds incompatible compiler flags (`-fno-exceptions`, `-std=gnu++17`).