### PR TITLE
Fix jsoncpp compilation error

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -7,6 +7,7 @@ fn main() {
             .define("OpenGL_GL_PREFERENCE", "GLVND")
             .define("DYNAMIC_LOADER", "OFF")
             .define("CMAKE_INSTALL_LIBDIR", "lib")
+            .define("BUILD_WITH_SYSTEM_JSONCPP", "OFF") // See https://github.com/KhronosGroup/OpenXR-SDK-Source/issues/481
             .profile("Release")
             .build();
 


### PR DESCRIPTION
Fixes https://github.com/Ralith/openxrs/issues/148.

It seems if the SDK detects jsoncpp on the system you can't build the loader as a static library unless you explicitly tell it to use the bundled jsoncpp(I think it's expecting to static link it which you can't do with the dynamic library it finds on the system).
