### PR TITLE
Add ndk-glue to dev-dependencies

### DIFF
--- a/openxr/Cargo.toml
+++ b/openxr/Cargo.toml
@@ -29,6 +29,9 @@ libloading = { version = "0.8", optional = true }
 ash = { version = "0.38", default-features = false, features = ["loaded"] }
 ctrlc = "3.1.5"
 
+[target.'cfg(target_os = "android")'.dev-dependencies]
+ndk-glue = "0.7"
+
 [target.'cfg(target_os = "android")'.dependencies]
 ndk-context = "0.1"
 


### PR DESCRIPTION
Otherwise getting a compile error
```
   Compiling openxr v0.19.0 (C:\Code\openxrs\openxr)
error[E0433]: failed to resolve: use of undeclared crate or module `ndk_glue`
  --> openxr\examples/vulkan.rs:24:35
   |
24 | #[cfg_attr(target_os = "android", ndk_glue::main)]
   |                                   ^^^^^^^^ use of undeclared crate or module `ndk_glue`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `openxr` (example "vulkan-android") due to 1 previous error
Error: Command `cargo build --target aarch64-linux-android --example vulkan-android` had a non-zero exit code.
```