### PR TITLE
Upgrade OpenXR-SDK 1.1.40 and small fixes on generator

### DIFF
--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -2358,6 +2358,9 @@ fn conditions(name: &str, ext: Option<&str>) -> TokenStream {
     if name.contains("android") {
         conditions.push(quote! { target_os = "android" });
     }
+    if name.contains("metal") {
+        conditions.push(quote! { target_vendor = "apple" });
+    }
     match conditions.len() {
         0 => quote! {},
         1 => quote! { #[cfg(#(#conditions)*)] },

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -1164,7 +1164,7 @@ impl Parser {
             let meta = self.compute_meta(name, s);
             let derives = if (meta.has_pointer || meta.has_array) && meta.has_unprintable {
                 quote! { #[derive(Copy, Clone)] }
-            } else if meta.has_pointer || meta.has_array {
+            } else if meta.has_pointer || meta.has_array && name != "XrUuid" {
                 quote! { #[derive(Copy, Clone, Debug)] }
             } else if meta.has_non_default {
                 quote! { #[derive(Copy, Clone, Debug, PartialEq)] }

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -1838,8 +1838,7 @@ impl Parser {
                     quote! { bool },
                     quote! { self.inner.#ident = value.into(); },
                 ),
-                x if self.handles.contains(x) => {
-                    assert!(m.len.is_none());
+                x if self.handles.contains(x) && m.len.is_none() => {
                     let ty = xr_var_ty(self.api_aliases.as_ref(), m);
                     (
                         quote! { &'a #ty #type_args },

--- a/openxr/src/passthrough.rs
+++ b/openxr/src/passthrough.rs
@@ -13,7 +13,6 @@ use crate::{
 };
 use std::ptr;
 use std::sync::Arc;
-use sys::PassthroughLayerFB;
 
 /// A [passthrough feature].
 ///
@@ -88,12 +87,12 @@ impl Drop for Passthrough {
 ///
 /// [`XR_FB_passthrough`]: https://www.khronos.org/registry/OpenXR/specs/1.1/html/xrspec.html#XR_FB_passthrough
 /// [passthrough layer]: https://developer.oculus.com/documentation/native/android/mobile-passthrough/#create-and-start-a-passthrough-layer
-pub struct PassthroughLayer {
+pub struct PassthroughLayerFB {
     pub(crate) session: Arc<session::SessionInner>,
     handle: sys::PassthroughLayerFB,
 }
 
-impl PassthroughLayer {
+impl PassthroughLayerFB {
     /// [Create](https://www.khronos.org/registry/OpenXR/specs/1.0/man/html/openxr.html#xrCreatePassthroughLayerFB)
     /// a passthrough layer.
     pub(crate) fn create<G>(
@@ -118,7 +117,7 @@ impl PassthroughLayer {
                 &mut handle,
             ))?;
         }
-        Ok(PassthroughLayer {
+        Ok(PassthroughLayerFB {
             session: session.inner.clone(),
             handle,
         })
@@ -144,12 +143,16 @@ impl PassthroughLayer {
         Ok(())
     }
 
-    pub fn inner(&self) -> &PassthroughLayerFB {
+    pub fn inner(&self) -> &sys::PassthroughLayerFB {
         &self.handle
+    }
+
+    pub fn as_raw(&self) -> sys::PassthroughLayerFB {
+        self.handle
     }
 }
 
-impl Drop for PassthroughLayer {
+impl Drop for PassthroughLayerFB {
     fn drop(&mut self) {
         unsafe {
             (fp(&self.session).destroy_passthrough_layer)(self.handle);

--- a/openxr/src/session.rs
+++ b/openxr/src/session.rs
@@ -530,8 +530,8 @@ impl<G: Graphics> Session<G> {
         passthrough: &Passthrough,
         flags: PassthroughFlagsFB,
         purpose: PassthroughLayerPurposeFB,
-    ) -> Result<PassthroughLayer> {
-        PassthroughLayer::create(self, passthrough, flags, purpose)
+    ) -> Result<PassthroughLayerFB> {
+        PassthroughLayerFB::create(self, passthrough, flags, purpose)
     }
 }
 


### PR DESCRIPTION
This works towards upgrading OpenXR-SDK 1.1.40, not yet the last version but tries to lay down the path after making some decisions related to use a more consisting naming on types without removing the vendor suffix.