### PR TITLE
Don't acquire `xrEnumerateApiLayerProperties` when running as an API layer

### DIFF
--- a/openxr/src/entry.rs
+++ b/openxr/src/entry.rs
@@ -86,9 +86,10 @@ impl Entry {
                     enumerate_instance_extension_properties: *lib
                         .get(b"xrEnumerateInstanceExtensionProperties\0")
                         .map_err(LoadError)?,
-                    enumerate_api_layer_properties: *lib
+                    enumerate_api_layer_properties: lib
                         .get(b"xrEnumerateApiLayerProperties\0")
-                        .map_err(LoadError)?,
+                        .map(|s| *s)
+                        .unwrap_or(crate::stub_enumerate_api_layer_properties),
                 },
                 _lib_guard: Some(lib),
             }),
@@ -123,11 +124,13 @@ impl Entry {
                             ),
                         )?,
                     ),
-                    enumerate_api_layer_properties: mem::transmute(get_instance_proc_addr_helper(
+                    enumerate_api_layer_properties: get_instance_proc_addr_helper(
                         get_instance_proc_addr,
                         sys::Instance::NULL,
                         CStr::from_bytes_with_nul_unchecked(b"xrEnumerateApiLayerProperties\0"),
-                    )?),
+                    )
+                    .map(|s| unsafe { mem::transmute(s) })
+                    .unwrap_or(crate::stub_enumerate_api_layer_properties),
                 },
                 #[cfg(feature = "loaded")]
                 _lib_guard: None,

--- a/openxr/src/generated.rs
+++ b/openxr/src/generated.rs
@@ -3417,10 +3417,13 @@ pub mod raw {
                     instance,
                     CStr::from_bytes_with_nul_unchecked(b"xrGetInstanceProcAddr\0"),
                 )?),
-                enumerate_api_layer_properties: mem::transmute(entry.get_instance_proc_addr(
-                    instance,
-                    CStr::from_bytes_with_nul_unchecked(b"xrEnumerateApiLayerProperties\0"),
-                )?),
+                enumerate_api_layer_properties: entry
+                    .get_instance_proc_addr(
+                        instance,
+                        CStr::from_bytes_with_nul_unchecked(b"xrEnumerateApiLayerProperties\0"),
+                    )
+                    .map(|s| unsafe { mem::transmute(s) })
+                    .unwrap_or(crate::stub_enumerate_api_layer_properties),
                 enumerate_instance_extension_properties: mem::transmute(
                     entry.get_instance_proc_addr(
                         instance,

--- a/openxr/src/lib.rs
+++ b/openxr/src/lib.rs
@@ -59,6 +59,19 @@ pub const USER_HEAD: &str = "/user/head";
 pub const USER_GAMEPAD: &str = "/user/gamepad";
 pub const USER_TREADMILL: &str = "/user/treadmill";
 
+/// Stub for the `xrEnumerateApiLayerProperties` entry point when it's not provided by the runtime.
+///
+/// # Safety
+///
+/// No this is actually safe but we need the type to match.
+unsafe extern "system" fn stub_enumerate_api_layer_properties(
+    _a: u32,
+    _b: *mut u32,
+    _c: *mut sys::ApiLayerProperties,
+) -> sys::Result {
+    panic!("Runtime didn't provide a xrEnumerateApiLayers entry point");
+}
+
 // FFI helpers
 fn cvt(x: sys::Result) -> Result<sys::Result> {
     if x.into_raw() >= 0 {


### PR DESCRIPTION
Honestly, this is not very nice, but the fact is both monado and SteamVR fails if their `xrGetInstanceProcAddr` functions are used to query "xrEnumerateApiLayerProperties". Monado returns `ERROR_NOT_SUPPORTED` if instance is not NULL, but will return a valid function if it is. On the other hand SteamVR returns `ERROR_HANDLE_INVALID` if instance _is_ NULL.

Given it doesn't really make sense to query API layers from an API layer, avoid all these troubles by not querying
"xrEnumerateApiLayerProperties" at all.

(Related: https://github.com/technobaboo/quark, this is a nicer version of https://github.com/Ralith/openxrs/commit/14824bfe883fde5d5e2c0e98b904a30d86d401f3)