### PR TITLE
fix(generator): generate unsafe extern for linked block

### DIFF
--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -1309,7 +1309,7 @@ impl Parser {
             #(#ext_consts)*
 
             #[cfg(feature = "linked")]
-            extern "system" {
+            unsafe extern "system" {
                 #(#protos)*
             }
         }

--- a/sys/src/generated.rs
+++ b/sys/src/generated.rs
@@ -13703,7 +13703,7 @@ pub const HTCX_vive_tracker_interaction_SPEC_VERSION: u32 = 3u32;
 pub const HTCX_VIVE_TRACKER_INTERACTION_EXTENSION_NAME: &[u8] =
     b"XR_HTCX_vive_tracker_interaction\0";
 #[cfg(feature = "linked")]
-extern "system" {
+unsafe extern "system" {
     #[link_name = "xrNegotiateLoaderRuntimeInterface"]
     pub fn negotiate_loader_runtime_interface(
         loader_info: *const NegotiateLoaderInfo,


### PR DESCRIPTION
[Rust 2024 made `extern` blocks `unsafe`](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-extern.html). The generated code didn't handle this for `linked` builds; easy enough fix.