### PR TITLE
add support for properly providing the Android `Activity` to the runtime

### DIFF
--- a/openxr/examples/hello.rs
+++ b/openxr/examples/hello.rs
@@ -36,6 +36,12 @@ fn main() {
             },
             &xr::ExtensionSet::default(),
             &[],
+            #[cfg(not(target_os = "android"))]
+            (),
+            #[cfg(target_os = "android")]
+            unsafe {
+                openxr::AndroidPlatformInfo::new(ndk_glue::native_activity().activity().cast())
+            },
         )
         .unwrap();
     let instance_props = instance.properties().unwrap();

--- a/openxr/examples/vulkan.rs
+++ b/openxr/examples/vulkan.rs
@@ -72,6 +72,12 @@ pub fn main() {
             },
             &enabled_extensions,
             &[],
+            #[cfg(not(target_os = "android"))]
+            (),
+            #[cfg(target_os = "android")]
+            unsafe {
+                openxr::AndroidPlatformInfo::new(ndk_glue::native_activity().activity().cast())
+            },
         )
         .unwrap();
     let instance_props = xr_instance.properties().unwrap();
@@ -257,13 +263,21 @@ pub fn main() {
                         vk::PipelineShaderStageCreateInfo {
                             stage: vk::ShaderStageFlags::VERTEX,
                             module: vert,
-                            p_name: c"main".as_ptr(),
+                            #[allow(
+                                clippy::manual_c_str_literals,
+                                reason = "ndk_glue::main cannot parse c string literals"
+                            )]
+                            p_name: b"main\0".as_ptr() as _,
                             ..Default::default()
                         },
                         vk::PipelineShaderStageCreateInfo {
                             stage: vk::ShaderStageFlags::FRAGMENT,
                             module: frag,
-                            p_name: c"main".as_ptr(),
+                            #[allow(
+                                clippy::manual_c_str_literals,
+                                reason = "ndk_glue::main cannot parse c string literals"
+                            )]
+                            p_name: b"main\0".as_ptr() as _,
                             ..Default::default()
                         },
                     ])

--- a/openxr/src/entry.rs
+++ b/openxr/src/entry.rs
@@ -181,8 +181,11 @@ impl Entry {
         Ok(())
     }
 
-    /// Create an OpenXR instance with certain extensions enabled. Android support can be enabled by
-    /// setting `khr_android_create_instance` to `true`.
+    /// Create an OpenXR instance with certain extensions enabled.
+    ///
+    /// On Android, pass [`AndroidPlatformInfo`] as `platform_info`
+    /// and set `khr_android_create_instance` to `true`.
+    /// On other platforms, pass `()`.
     ///
     /// Most applications will want to enable at least one graphics API extension
     /// (e.g. `khr_vulkan_enable2`) so that a `Session` can be created for rendering.
@@ -191,6 +194,7 @@ impl Entry {
         app_info: &ApplicationInfo,
         required_extensions: &ExtensionSet,
         layers: &[&str],
+        platform_info: impl PlatformInfo,
     ) -> Result<Instance> {
         assert!(
             app_info.application_name.len() < sys::MAX_APPLICATION_NAME_SIZE,
@@ -216,29 +220,9 @@ impl Entry {
             .map(|x| x.as_ptr() as *const _)
             .collect::<Vec<_>>();
 
-        #[cfg(not(target_os = "android"))]
-        let next = ptr::null();
-        #[cfg(target_os = "android")]
-        let android_info = {
-            let context = ndk_context::android_context();
-
-            sys::InstanceCreateInfoAndroidKHR {
-                ty: sys::InstanceCreateInfoAndroidKHR::TYPE,
-                next: ptr::null(),
-                application_vm: context.vm(),
-                application_activity: context.context(),
-            }
-        };
-        #[cfg(target_os = "android")]
-        let next = if required_extensions.khr_android_create_instance {
-            &android_info as *const _ as _
-        } else {
-            ptr::null()
-        };
-
         let mut info = sys::InstanceCreateInfo {
             ty: sys::InstanceCreateInfo::TYPE,
-            next,
+            next: ptr::null_mut(),
             create_flags: Default::default(),
             application_info: sys::ApplicationInfo {
                 application_name: [0; sys::MAX_APPLICATION_NAME_SIZE],
@@ -258,9 +242,7 @@ impl Entry {
         );
         place_cstr(&mut info.application_info.engine_name, app_info.engine_name);
         unsafe {
-            let mut handle = sys::Instance::NULL;
-            cvt((self.fp().create_instance)(&info, &mut handle))?;
-
+            let handle = platform_info.create_instance(self, info)?;
             let exts = InstanceExtensions::load(self, handle, required_extensions)?;
             Instance::from_raw(self.clone(), handle, exts)
         }
@@ -413,4 +395,78 @@ pub struct ApiLayerProperties {
     pub spec_version: Version,
     pub layer_version: u32,
     pub description: String,
+}
+
+/// # Safety
+///
+/// [`PlatformInfo::create_instance`] must return a valid [`sys::Instance`] handle, or an error.
+pub unsafe trait PlatformInfo {
+    /// # Safety
+    ///
+    /// `info` must be valid to be passed to `xrCreateInstance`
+    unsafe fn create_instance(
+        &self,
+        entry: &Entry,
+        info: sys::InstanceCreateInfo,
+    ) -> Result<sys::Instance>;
+}
+
+unsafe impl PlatformInfo for () {
+    unsafe fn create_instance(
+        &self,
+        entry: &Entry,
+        info: sys::InstanceCreateInfo,
+    ) -> Result<sys::Instance> {
+        let mut handle = sys::Instance::NULL;
+        // SAFETY: guaranteed by the caller
+        cvt(unsafe { (entry.fp().create_instance)(&info, &mut handle) })?;
+        Ok(handle)
+    }
+}
+
+#[cfg(target_os = "android")]
+pub struct AndroidPlatformInfo {
+    activity: *mut std::ffi::c_void,
+}
+
+#[cfg(target_os = "android")]
+impl AndroidPlatformInfo {
+    /// Creates a struct holding Android specific information for instance creation.
+    ///
+    /// Some information will also be fetched from [`ndk_context`],
+    /// so your NDK glue code has to initialize it.
+    ///
+    /// # Safety
+    ///
+    /// The `activity` pointer has to be a valid JNI reference to an `android.app.Activity`,
+    /// as required by the [XR_KHR_android_create_instance] extension.
+    ///
+    /// [XR_KHR_android_create_instance]: https://registry.khronos.org/OpenXR/specs/1.1/html/xrspec.html#XR_KHR_android_create_instance
+    pub unsafe fn new(activity: *mut std::ffi::c_void) -> Self {
+        Self { activity }
+    }
+}
+
+#[cfg(target_os = "android")]
+unsafe impl PlatformInfo for AndroidPlatformInfo {
+    unsafe fn create_instance(
+        &self,
+        entry: &Entry,
+        mut info: sys::InstanceCreateInfo,
+    ) -> Result<sys::Instance> {
+        let context = ndk_context::android_context();
+        let mut android_info = sys::InstanceCreateInfoAndroidKHR {
+            ty: sys::InstanceCreateInfoAndroidKHR::TYPE,
+            next: info.next,
+            application_vm: context.vm(),
+            application_activity: self.activity,
+        };
+        info.next = (&mut android_info as *mut sys::InstanceCreateInfoAndroidKHR).cast();
+
+        let mut handle = sys::Instance::NULL;
+        // SAFETY: `info` was guaranteed to be valid by the caller,
+        // and a valid struct was added into the next chain
+        cvt(unsafe { (entry.fp().create_instance)(&info, &mut handle) })?;
+        Ok(handle)
+    }
 }


### PR DESCRIPTION
The context provided by `ndk-context` is not guaranteed to be an `Activity` context.

The `android-activity` crate has recently changed to providing an `Application` context to `ndk-context` instead (https://github.com/rust-mobile/android-activity/pull/229), but `XR_KHR_android_create_instance` requires a reference to the `Activity`.

The new `create_instance_android` function requires the user to pass in the `Activity` reference themselves.

Trying to use the normal `create_instance` function will produce the following error, which points users to the correct function:
```
error[E0599]: no method named `create_instance` found for reference `&openxr::Entry` in the current scope                                                                                                                                                              
  --> main.rs:73:26
   |
73 |     let instance = entry.create_instance(
   |                    ------^^^^^^^^^^^^^^^
   |
help: there is a method `create_instance_android` with a similar name
   |
73 |     let instance = entry.create_instance_android(
   |                                         ++++++++

For more information about this error, try `rustc --explain E0599`.                                                                                                                                                                                                    
error: could not compile `engine` (lib) due to 1 previous error                                                                                                                                                                                                        
Error: Command `cargo build --target aarch64-linux-android` had a non-zero exit code.
```

The `vulkan` example didn't compile for Android anymore, because the `ndk_glue::main` proc-macro doesn't parse c string literals. `ndk-glue` was deprecated some time ago (https://github.com/rust-mobile/ndk/issues/372), and should probably be replaced with `android-activity`.